### PR TITLE
Match new git "up to date" message format

### DIFF
--- a/lib/capistrano/tasks/confirm_branch.rake
+++ b/lib/capistrano/tasks/confirm_branch.rake
@@ -39,7 +39,7 @@ namespace :confirm_branch do
       fetch(:check_unpushed_commits_before_deploy, true)
       pending_commits = `git status`
 
-      unless pending_commits[/Your branch is up-to-date/]
+      unless pending_commits[/Your branch is up.to.date/]
         pending_commits = /(Your branch is ahead of '\S*' by \d commits?)/.
           match(pending_commits).captures.first
 


### PR DESCRIPTION
New Format:

`Your branch is up to date with 'origin/master'`

Old Format:

`Your branch is up-to-date with 'origin/master'`

This regex supports both. Closes #4 